### PR TITLE
Made a bunch of improvements to the grammar file

### DIFF
--- a/grammars/miniyaml.cson
+++ b/grammars/miniyaml.cson
@@ -8,93 +8,9 @@
     'include': '#comment'
   }
   {
-    # - >
-    # - |
-    # - hello: >
-    # - hello: |
-    'begin': '^(\\s*)(?:(-)|(?:(?:(-)(\\s*))?([^!@#%&*>,][^:#]*\\S)\\s*(:)))(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
-    'beginCaptures':
-      '2':
-        'name': 'punctuation.definition.entry.yaml'
-      '3':
-        'name': 'punctuation.definition.entry.yaml'
-      '5':
-        'name': 'entity.name.tag.yaml'
-      '6':
-        'name': 'punctuation.separator.key-value.yaml'
-      '7':
-        'name': 'keyword.other.tag.local.yaml'
-      '8':
-        'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^((?!$)(?!\\1\\s+)|(?=\\s\\4(-|[^\\s!@#%&*>,].*:\\s+)))'
-    'contentName': 'string.unquoted.block.yaml'
-    'patterns': [
-      {
-        # Comments can only appear on the same line as the tag name
-        'begin': '\\G'
-        'end': '$'
-        'patterns': [
-          {
-            'include': '#comment'
-          }
-        ]
-      }
-      {
-        'include': '#constants'
-      }
-    ]
-  }
-  {
-    # hello: >
-    # hello: |
-    'begin': '^(\\s*)([^!@#%&*>,][^:#]*\\S)\\s*(:)(?:\\s+((!)[^!\\s]+))?\\s+(?=\\||>)'
-    'beginCaptures':
-      '2':
-        'name': 'entity.name.tag.yaml'
-      '3':
-        'name': 'punctuation.separator.key-value.yaml'
-      '4':
-        'name': 'keyword.other.tag.local.yaml'
-      '5':
-        'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^(?!$)(?!\\1\\s+)'
-    'contentName': 'string.unquoted.block.yaml'
-    'patterns': [
-      {
-        # Comments can only appear on the same line as the tag name
-        'begin': '\\G'
-        'end': '$'
-        'patterns': [
-          {
-            'include': '#comment'
-          }
-        ]
-      }
-      {
-        'include': '#constants'
-      }
-    ]
-  }
-  {
-    # << : *variableToMerge
-    'match': '(<<)\\s*(:)\\s+(.+)$'
-    'captures':
-      '1':
-        'name': 'entity.name.tag.merge.yaml'
-      '2':
-        'name': 'punctuation.separator.key-value.yaml'
-      '3':
-        'patterns': [
-          {
-            'include': '#variables'
-          }
-        ]
-  }
-  {
     # - hello:
     # look at me go:
-    # TODO remove: !!omap
-    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#]*?)(:)\\s+((!!)omap)?'
+    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#]*?)(:)\\s+'
     'beginCaptures':
       '2':
         'name': 'punctuation.definition.entry.yaml'
@@ -102,10 +18,6 @@
         'name': 'entity.name.tag.yaml'
       '4':
         'name': 'punctuation.separator.key-value.yaml'
-      '5':
-        'name': 'keyword.other.omap.yaml'
-      '6':
-        'name': 'punctuation.definition.tag.omap.yaml'
     'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
     'patterns': [
       {
@@ -114,70 +26,7 @@
     ]
   }
   {
-    # - 'quoted':
-    # "quoted":
-    # TODO remove: !!omap
-    'begin': '^(\\s*)(-)?\\s*(?:((\')([^\']*?)(\'))|((")([^"]*?)(")))(:)\\s+((!!)omap)?'
-    'beginCaptures':
-      '2':
-        'name': 'punctuation.definition.entry.yaml'
-      '3':
-        'name': 'string.quoted.single.yaml'
-      '4':
-        'name': 'punctuation.definition.string.begin.yaml'
-      '5':
-        'name': 'entity.name.tag.yaml'
-      '6':
-        'name': 'punctuation.definition.string.end.yaml'
-      '7':
-        'name': 'string.quoted.double.yaml'
-      '8':
-        'name': 'punctuation.definition.string.begin.yaml'
-      '9':
-        'name': 'entity.name.tag.yaml'
-      '10':
-        'name': 'punctuation.definition.string.end.yaml'
-      '11':
-        'name': 'punctuation.separator.key-value.yaml'
-      '12':
-        'name': 'keyword.other.omap.yaml'
-      '13':
-        'name': 'punctuation.definition.tag.omap.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
-    'patterns': [
-      {
-        'include': '#scalar-content'
-      }
-    ]
-  }
-  {
-    # - stuff
-    # - TODO remove: !!omap
-    # -
-    'begin': '^(\\s*)(-)\\s+(?:((!!)omap)|((!)[^!\\s]+)|(?![!@#%&*>,]))'
-    'beginCaptures':
-      '2':
-        'name': 'punctuation.definition.entry.yaml'
-      '3':
-        'name': 'keyword.other.omap.yaml'
-      '4':
-        'name': 'punctuation.definition.tag.omap.yaml'
-      '5':
-        'name': 'keyword.other.tag.local.yaml'
-      '6':
-        'name': 'punctuation.definition.tag.local.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
-    'patterns': [
-      {
-        'include': '#scalar-content'
-      }
-    ]
-  }
-  {
-    'include': '#variables'
-  }
-  {
-    'include': '#strings'
+    'include': '#strings' # For list values that take up an entire line and are not proper nodes.
   }
 ]
 'repository':
@@ -189,37 +38,8 @@
     'end': '$'
     'name': 'comment.line.number-sign.yaml'
   'constants':
-    'match': '(?<=\\s)(true|false|True|False|TRUE|FALSE|yes|no|Yes|No|YES|NO|~)(?=\\s*$)'
+    'match': '(?<=\\s)(true|false|True|False|TRUE|FALSE|~)(?=\\s*$)'
     'name': 'constant.language.yaml'
-  'date':
-    'match': '([0-9]{4}-[0-9]{2}-[0-9]{2})\\s*($|(?=#)(?!#{))'
-    'captures':
-      '1':
-        'name': 'constant.other.date.yaml'
-  'escaped_char':
-    # http://yaml.org/spec/1.2/spec.html#id2776092
-    'patterns': [
-      {
-        'match': '\\\\u[A-Fa-f0-9]{4}'
-        'name': 'constant.character.escape.yaml'
-      }
-      {
-        'match': '\\\\U[A-Fa-f0-9]{8}'
-        'name': 'constant.character.escape.yaml'
-      }
-      {
-        'match': '\\\\x[0-9A-Fa-f]{2}'
-        'name': 'constant.character.escape.yaml'
-      }
-      {
-        'match': '\\\\[0abtnvfre "/\\\\N_LP]' # Space is intentional
-        'name': 'constant.character.escape.yaml'
-      }
-      {
-        'match': '\\\\(u.{4}|U.{8}|x.{2}|.)'
-        'name': 'invalid.illegal.escape.yaml'
-      }
-    ]
   'numeric':
     # http://www.yaml.org/spec/1.2/spec.html#id2805071
     'patterns': [
@@ -251,60 +71,6 @@
   'strings':
     'patterns': [
       {
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.yaml'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.yaml'
-        'name': 'string.quoted.double.yaml'
-        'patterns': [
-          {
-            'include': '#escaped_char'
-          }
-        ]
-      }
-      {
-        # Per http://www.yaml.org/spec/1.2/spec.html#id2788097, only single quotes can be escaped
-        'begin': "'"
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.yaml'
-        'end': "'"
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.yaml'
-        'name': 'string.quoted.single.yaml'
-        'applyEndPatternLast': true
-        'patterns': [
-          {
-            'match': "''"
-            'name': 'constant.character.escape.yaml'
-          }
-        ]
-      }
-      {
-        'begin': '`'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.yaml'
-        'end': '`'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.yaml'
-        'name': 'string.interpolated.yaml'
-        'patterns': [
-          {
-            'include': '#escaped_char'
-          }
-          {
-            'include': '#erb'
-          }
-        ]
-      }
-      {
         'match': '[^\\s"\'\\n](?!\\s*#(?!{))([^#\\n]|((?<!\\s)#))*'
         'name': 'string.unquoted.yaml'
       }
@@ -322,18 +88,9 @@
         'include': '#constants'
       }
       {
-        'include': '#date'
-      }
-      {
         'include': '#numeric'
       }
       {
         'include': '#strings'
       }
     ]
-  'variables':
-    'captures':
-      '1':
-        'name': 'punctuation.definition.variable.yaml'
-    'match': '(&|\\*)\\w+$'
-    'name': 'variable.other.yaml'

--- a/grammars/miniyaml.cson
+++ b/grammars/miniyaml.cson
@@ -8,28 +8,18 @@
     'include': '#comment'
   }
   {
-    # - hello:
-    # look at me go:
-    'begin': '(?>^(\\s*)(-)?\\s*)([^!{@#%&*>,\'"][^#]*?)(:)\\s+'
-    'beginCaptures':
-      '2':
-        'name': 'punctuation.definition.entry.yaml'
-      '3':
-        'name': 'entity.name.tag.yaml'
-      '4':
-        'name': 'punctuation.separator.key-value.yaml'
-    'end': '^((?!\\1\\s+)|(?=\\1\\s*(-|[^!@#%&*>,].*:\\s+|#)))'
-    'patterns': [
-      {
-        'include': '#scalar-content'
-      }
-    ]
-  }
-  {
-    'include': '#strings' # For list values that take up an entire line and are not proper nodes.
+    'include': '#node'
   }
 ]
 'repository':
+  'block-pair':
+    'begin': '^\\t*(\\S+?)(?=(:))'
+    'beginCaptures':
+      '1':
+        'name': 'entity.name.tag.yaml'
+      '2':
+        'name': 'punctuation.definition.entry.yaml'
+    'end': ':(?=\\s|$)'
   'comment':
     'begin': '(?<=^|\\s)#(?!{)'
     'beginCaptures':
@@ -40,6 +30,15 @@
   'constants':
     'match': '(?<=\\s)(true|false|True|False|TRUE|FALSE|~)(?=\\s*$)'
     'name': 'constant.language.yaml'
+  'node':
+    'patterns': [
+      {
+        'include': '#block-pair'
+      }
+      {
+        'include': '#scalar-content'
+      }
+    ]
   'numeric':
     # http://www.yaml.org/spec/1.2/spec.html#id2805071
     'patterns': [

--- a/grammars/miniyaml.cson
+++ b/grammars/miniyaml.cson
@@ -33,12 +33,18 @@
   'node':
     'patterns': [
       {
+        'include': '#node-removal'
+      }
+      {
         'include': '#block-pair'
       }
       {
         'include': '#scalar-content'
       }
     ]
+  'node-removal':
+    'match': '^\\t+(-.+?)(?=:)'
+    'name': 'entity.yaml'
   'numeric':
     # http://www.yaml.org/spec/1.2/spec.html#id2805071
     'patterns': [

--- a/grammars/miniyaml.cson
+++ b/grammars/miniyaml.cson
@@ -13,13 +13,13 @@
 ]
 'repository':
   'block-pair':
-    'begin': '^\\t*(\\S+?)(?=(:))'
-    'beginCaptures':
-      '1':
-        'name': 'entity.name.tag.yaml'
-      '2':
-        'name': 'punctuation.definition.entry.yaml'
-    'end': ':(?=\\s|$)'
+    'match': '^\\t*(\\S+?)(?=@|:)'
+    'name': 'entity.name.tag.yaml'
+    'patterns': [
+      {
+        'include': '#node-identifier' # Including here because "block-pair" captures the entire line, including the value, so this is a subgroup.
+      }
+    ]
   'comment':
     'begin': '(?<=^|\\s)#(?!{)'
     'beginCaptures':
@@ -28,7 +28,7 @@
     'end': '$'
     'name': 'comment.line.number-sign.yaml'
   'constants':
-    'match': '(?<=\\s)(true|false|True|False|TRUE|FALSE|~)(?=\\s*$)'
+    'match': '(?::\\s)(true|false|True|False|TRUE|FALSE|~)(?=\\s*$)'
     'name': 'constant.language.yaml'
   'node':
     'patterns': [
@@ -39,37 +39,43 @@
         'include': '#block-pair'
       }
       {
+        'include': '#node-identifier' # Including here because "node-removal" captures only the node key, so this needs to be a follow-up group.
+      }
+      {
         'include': '#scalar-content'
       }
     ]
+  'node-identifier':
+    'match': '(?<=\\S)(@\\S+)(?=:\\s)'
+    'name': 'support.yaml'
   'node-removal':
-    'match': '^\\t+(-.+?)(?=:)'
+    'match': '^\\t+(-.+?)(?=@|:\\s)'
     'name': 'entity.yaml'
   'numeric':
     # http://www.yaml.org/spec/1.2/spec.html#id2805071
     'patterns': [
       {
-        'match': '[-+]?[0-9]+(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)[-+]?[0-9]+(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.integer.yaml'
       }
       {
-        'match': '0o[0-7]+(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)0o[0-7]+(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.octal.yaml'
       }
       {
-        'match': '0x[0-9a-fA-F]+(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)0x[0-9a-fA-F]+(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.hexadecimal.yaml'
       }
       {
-        'match': '[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.float.yaml'
       }
       {
-        'match': '[-+]?(\.inf|\.Inf|\.INF)(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)[-+]?(\.inf|\.Inf|\.INF)(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.float.yaml'
       }
       {
-        'match': '(\.nan|\.NaN|\.NAN)(?=\\s*($|#(?!#{)))'
+        'match': '(?::\\s)(\.nan|\.NaN|\.NAN)(?=\\s*($|#(?!#{)))'
         'name': 'constant.numeric.float.yaml'
       }
     ]
@@ -84,10 +90,6 @@
     'patterns': [
       {
         'include': '#comment'
-      }
-      {
-        'match': '!(?=\\s)'
-        'name': 'punctuation.definition.tag.non-specific.yaml'
       }
       {
         'include': '#constants'


### PR DESCRIPTION
This follows the ideas of https://github.com/OpenRA/MiniYAML.tmbundle/pull/1 - https://github.com/OpenRA/MiniYAML.tmbundle/pull/3 and gets the highlighting and rules structure mostly in line with that.
 - Removes a bunch of YAML-specific rules that don't apply to MiniYAML, greatly simplifying the entire thing.
 - Fixes several highlighting bugs caused by rules inherited from YAML.
 - Made incorrect indentation break highlighting for the line.
 - Added special highlighting for node removal.
 - Added special highlighting for node identifiers.

Some useful resources that helped with my work:
 - [Lightshow](https://github-lightshow.herokuapp.com/) - for testing GitHub's syntax highlighter on the fly. 
 - [regex101](https://regex101.com/) - for RegEx testing and explanations.
 - [Naming conventions docs](https://macromates.com/manual/en/language_grammars).
 - [My highlighting test file](https://github.com/penev92/OpenRA/blob/highlightingTest/mods/ts/A_highlighting_test.yaml).